### PR TITLE
feat(cli): add `cortex init --setup` for Claude Code integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+cortex = ["templates/*.md"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 120

--- a/src/cortex/__main__.py
+++ b/src/cortex/__main__.py
@@ -8,6 +8,8 @@ Usage:
     cortex reset               # clear store + state for current project
     cortex status              # show project hash, event count, storage tier
     cortex init                # print hook JSON for Claude Code settings
+    cortex init --setup        # also create .claude/rules/ files
+    cortex init --setup --force  # overwrite existing .claude/rules/ files
     cortex upgrade             # migrate from Tier 0 (JSON) to Tier 1 (SQLite)
     cortex upgrade --dry-run   # show what would be done without making changes
     cortex upgrade --force     # overwrite existing SQLite database
@@ -27,7 +29,7 @@ from cortex.hooks import (
     read_payload,
 )
 
-USAGE = "Usage: cortex <stop|precompact|session-start|user-prompt-submit|reset|status|init|upgrade|mcp-server>\n"
+USAGE = "Usage: cortex <stop|precompact|session-start|user-prompt-submit|reset|status|init|upgrade|mcp-server>\n\nCommands:\n  init [--setup] [--force]  Print hook JSON; --setup creates .claude/rules/ files\n  upgrade [--dry-run] [-f]  Migrate to next storage tier\n  status                    Show project info and event count\n  reset                     Clear all Cortex memory for project\n  mcp-server                Start MCP server (Tier 3)\n"
 
 
 def main() -> None:
@@ -46,7 +48,10 @@ def main() -> None:
     if arg == "status":
         sys.exit(cmd_status())
     if arg == "init":
-        sys.exit(cmd_init())
+        # Parse --setup and --force flags
+        setup = "--setup" in sys.argv or "-s" in sys.argv
+        force = "--force" in sys.argv or "-f" in sys.argv
+        sys.exit(cmd_init(setup=setup, force=force))
     if arg == "upgrade":
         # Parse --dry-run and --force flags
         dry_run = "--dry-run" in sys.argv or "-n" in sys.argv

--- a/src/cortex/__main__.py
+++ b/src/cortex/__main__.py
@@ -29,7 +29,16 @@ from cortex.hooks import (
     read_payload,
 )
 
-USAGE = "Usage: cortex <stop|precompact|session-start|user-prompt-submit|reset|status|init|upgrade|mcp-server>\n\nCommands:\n  init [--setup] [--force]  Print hook JSON; --setup creates .claude/rules/ files\n  upgrade [--dry-run] [-f]  Migrate to next storage tier\n  status                    Show project info and event count\n  reset                     Clear all Cortex memory for project\n  mcp-server                Start MCP server (Tier 3)\n"
+USAGE = (
+    "Usage: cortex <stop|precompact|session-start|user-prompt-submit|"
+    "reset|status|init|upgrade|mcp-server>\n\n"
+    "Commands:\n"
+    "  init [--setup] [--force]  Print hook JSON; --setup creates .claude/rules/ files\n"
+    "  upgrade [--dry-run] [-f]  Migrate to next storage tier\n"
+    "  status                    Show project info and event count\n"
+    "  reset                     Clear all Cortex memory for project\n"
+    "  mcp-server                Start MCP server (Tier 3)\n"
+)
 
 
 def main() -> None:

--- a/src/cortex/cli.py
+++ b/src/cortex/cli.py
@@ -8,6 +8,8 @@ Claude Code settings. Upgrade migrates from Tier 0 (JSON) to Tier 1 (SQLite).
 import json
 import os
 import sys
+from importlib import resources
+from pathlib import Path
 
 from cortex.config import load_config
 from cortex.db import check_fts5_available, get_db_path
@@ -219,6 +221,60 @@ def cmd_upgrade(cwd: str | None = None, dry_run: bool = False, force: bool = Fal
         return 1
 
 
+def setup_claude_rules(cwd: str, force: bool = False) -> dict:
+    """Create .claude/rules/ directory and copy Cortex template files.
+
+    Creates:
+    - .claude/rules/cortex-memory-instructions.md (from package template)
+    - .claude/rules/cortex-briefing.md (empty placeholder)
+
+    Args:
+        cwd: Project directory to set up.
+        force: If True, overwrite existing files.
+
+    Returns:
+        Dict with 'created', 'skipped', and 'errors' lists.
+    """
+    result: dict = {"created": [], "skipped": [], "errors": []}
+    project_path = Path(cwd)
+    rules_dir = project_path / ".claude" / "rules"
+
+    # Create .claude/rules/ directory
+    try:
+        rules_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        result["errors"].append(f"Failed to create {rules_dir}: {e}")
+        return result
+
+    # Copy cortex-memory-instructions.md from package templates
+    memory_instructions_dest = rules_dir / "cortex-memory-instructions.md"
+    if memory_instructions_dest.exists() and not force:
+        result["skipped"].append(str(memory_instructions_dest))
+    else:
+        try:
+            # Use importlib.resources to get template from package
+            template_files = resources.files("cortex.templates")
+            template_content = (template_files / "cortex-memory-instructions.md").read_text()
+            memory_instructions_dest.write_text(template_content)
+            result["created"].append(str(memory_instructions_dest))
+        except Exception as e:
+            result["errors"].append(f"Failed to create {memory_instructions_dest}: {e}")
+
+    # Create empty cortex-briefing.md
+    briefing_dest = rules_dir / "cortex-briefing.md"
+    if briefing_dest.exists() and not force:
+        result["skipped"].append(str(briefing_dest))
+    else:
+        try:
+            briefing_content = "<!-- Cortex briefing - auto-populated by cortex session-start -->\n"
+            briefing_dest.write_text(briefing_content)
+            result["created"].append(str(briefing_dest))
+        except Exception as e:
+            result["errors"].append(f"Failed to create {briefing_dest}: {e}")
+
+    return result
+
+
 def get_init_hook_json(include_tier2: bool = False, include_tier3: bool = False) -> str:
     """Return the hook configuration JSON for Claude Code settings.
 
@@ -253,12 +309,46 @@ def get_init_hook_json(include_tier2: bool = False, include_tier3: bool = False)
     return json.dumps({"hooks": hooks}, indent=2)
 
 
-def cmd_init() -> int:
-    """Print hook configuration JSON to stdout for copy-paste into Claude Code settings.
+def cmd_init(cwd: str | None = None, setup: bool = False, force: bool = False) -> int:
+    """Print hook configuration JSON and optionally set up .claude/rules/ files.
 
     If current project is Tier 2+, includes UserPromptSubmit hook for anticipatory retrieval.
     If Tier 3, includes projection regeneration and MCP server instructions.
+
+    Args:
+        cwd: Working directory (uses os.getcwd() if None).
+        setup: If True, create .claude/rules/ with Cortex template files.
+        force: If True, overwrite existing files (only used with setup=True).
+
+    Returns:
+        0 on success, 1 on error.
     """
+    work_dir = (os.getcwd() if cwd is None else cwd).strip()
+
+    # Handle --setup: create .claude/rules/ files
+    if setup:
+        if not work_dir:
+            print("Cortex init: no cwd.", file=sys.stderr)
+            return 1
+
+        result = setup_claude_rules(work_dir, force=force)
+
+        # Report results
+        if result["created"]:
+            for path in result["created"]:
+                print(f"Created: {path}")
+        if result["skipped"]:
+            for path in result["skipped"]:
+                print(f"Skipped (exists): {path}")
+            if not force:
+                print("Use --force to overwrite existing files.", file=sys.stderr)
+        if result["errors"]:
+            for error in result["errors"]:
+                print(f"Error: {error}", file=sys.stderr)
+            return 1
+
+        print()  # Blank line before hook JSON
+
     config = load_config()
     include_tier2 = config.storage_tier >= 2 or config.auto_embed
     include_tier3 = config.storage_tier >= 3 or config.projections_enabled
@@ -272,5 +362,8 @@ def cmd_init() -> int:
         print("\n# Tier 2+ detected: UserPromptSubmit hook included for anticipatory retrieval", file=sys.stderr)
     else:
         print("\n# Tip: Upgrade to Tier 2 and re-run 'cortex init' for anticipatory retrieval", file=sys.stderr)
+
+    if setup and result["created"]:
+        print("\n# Claude Code integration files created. Add the hooks JSON above to your settings.", file=sys.stderr)
 
     return 0

--- a/src/cortex/cli.py
+++ b/src/cortex/cli.py
@@ -236,7 +236,13 @@ def setup_claude_rules(cwd: str, force: bool = False) -> dict:
         Dict with 'created', 'skipped', and 'errors' lists.
     """
     result: dict = {"created": [], "skipped": [], "errors": []}
-    project_path = Path(cwd)
+
+    # Validate cwd is not empty or whitespace
+    if not cwd or not cwd.strip():
+        result["errors"].append("Invalid project directory: cwd is empty or whitespace")
+        return result
+
+    project_path = Path(cwd.strip())
     rules_dir = project_path / ".claude" / "rules"
 
     # Create .claude/rules/ directory

--- a/src/cortex/templates/__init__.py
+++ b/src/cortex/templates/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for cortex.templates - contains template files for cortex init --setup

--- a/src/cortex/templates/cortex-memory-instructions.md
+++ b/src/cortex/templates/cortex-memory-instructions.md
@@ -1,0 +1,24 @@
+# Cortex memory instructions (Layer 3)
+
+Cortex persists important context across sessions. Use the `[MEMORY: ...]` tag when you want something to be remembered in future sessions.
+
+## When to use [MEMORY:]
+
+- **Decisions:** After choosing an approach, technology, or design (e.g. "Use SQLite for storage", "Prefer double quotes for strings").
+- **Rejections:** When you explicitly reject an alternative and why (e.g. "Rejected PostgreSQL — zero-config requirement").
+- **Preferences:** User or project preferences that affect future work (e.g. "Tests live in tests/, not test/").
+- **Important facts:** One-off discoveries that future sessions should know (e.g. "The API key is read from env X").
+
+## What to put inside the tag
+
+- Keep it short: one sentence or a short bullet list.
+- Be specific: "Use SQLite" is better than "We chose a database."
+- No code: put the *fact* in the tag; code lives in the codebase.
+
+## Example
+
+- `[MEMORY: Use SQLite for local storage — zero-config, single file.]`
+- `[MEMORY: Rejected MongoDB — overkill for single-user; no need for scaling.]`
+- `[MEMORY: User prefers pytest over unittest; tests in tests/ with -v.]`
+
+Cortex will extract these and include them in the briefing loaded at the start of each new session.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import json
 import sys
 from io import StringIO
 
-from cortex.cli import cmd_init, cmd_reset, cmd_status, get_init_hook_json
+from cortex.cli import cmd_init, cmd_reset, cmd_status, get_init_hook_json, setup_claude_rules
 from cortex.project import get_project_hash
 from cortex.store import EventStore, HookState
 
@@ -127,3 +127,133 @@ class TestCmdInit:
         data = json.loads(out)
         assert "hooks" in data
         assert "Stop" in data["hooks"]
+
+    def test_init_with_setup_creates_rules_files(self, tmp_path):
+        """Test cortex init --setup creates .claude/rules/ files."""
+        old_stdout = sys.stdout
+        try:
+            sys.stdout = StringIO()
+            code = cmd_init(cwd=str(tmp_path), setup=True)
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+
+        assert code == 0
+
+        # Check files were created
+        rules_dir = tmp_path / ".claude" / "rules"
+        assert rules_dir.exists()
+
+        memory_file = rules_dir / "cortex-memory-instructions.md"
+        assert memory_file.exists()
+        content = memory_file.read_text()
+        assert "[MEMORY:" in content  # Template content check
+
+        briefing_file = rules_dir / "cortex-briefing.md"
+        assert briefing_file.exists()
+        assert "auto-populated" in briefing_file.read_text()
+
+        # Check output mentions created files
+        assert "Created:" in out
+
+    def test_init_with_setup_empty_cwd_returns_one(self):
+        """Test cortex init --setup with empty cwd fails."""
+        code = cmd_init(cwd="", setup=True)
+        assert code == 1
+
+
+class TestSetupClaudeRules:
+    """Test setup_claude_rules creates .claude/rules/ files."""
+
+    def test_creates_rules_directory(self, tmp_path):
+        """Test creates .claude/rules/ directory structure."""
+        result = setup_claude_rules(str(tmp_path))
+
+        rules_dir = tmp_path / ".claude" / "rules"
+        assert rules_dir.exists()
+        assert rules_dir.is_dir()
+        assert len(result["errors"]) == 0
+
+    def test_creates_memory_instructions_file(self, tmp_path):
+        """Test creates cortex-memory-instructions.md from template."""
+        result = setup_claude_rules(str(tmp_path))
+
+        memory_file = tmp_path / ".claude" / "rules" / "cortex-memory-instructions.md"
+        assert memory_file.exists()
+        assert str(memory_file) in result["created"]
+
+        # Check it has expected content from template
+        content = memory_file.read_text()
+        assert "Cortex" in content
+        assert "[MEMORY:" in content
+        assert "Layer 3" in content
+
+    def test_creates_briefing_file(self, tmp_path):
+        """Test creates empty cortex-briefing.md placeholder."""
+        result = setup_claude_rules(str(tmp_path))
+
+        briefing_file = tmp_path / ".claude" / "rules" / "cortex-briefing.md"
+        assert briefing_file.exists()
+        assert str(briefing_file) in result["created"]
+
+        content = briefing_file.read_text()
+        assert "auto-populated" in content
+        assert "cortex session-start" in content
+
+    def test_skips_existing_files_without_force(self, tmp_path):
+        """Test does not overwrite existing files unless force=True."""
+        # Create existing files
+        rules_dir = tmp_path / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+
+        memory_file = rules_dir / "cortex-memory-instructions.md"
+        memory_file.write_text("existing content")
+
+        briefing_file = rules_dir / "cortex-briefing.md"
+        briefing_file.write_text("existing briefing")
+
+        result = setup_claude_rules(str(tmp_path), force=False)
+
+        # Files should be skipped
+        assert str(memory_file) in result["skipped"]
+        assert str(briefing_file) in result["skipped"]
+        assert len(result["created"]) == 0
+
+        # Content should be unchanged
+        assert memory_file.read_text() == "existing content"
+        assert briefing_file.read_text() == "existing briefing"
+
+    def test_overwrites_with_force(self, tmp_path):
+        """Test overwrites existing files when force=True."""
+        # Create existing files
+        rules_dir = tmp_path / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+
+        memory_file = rules_dir / "cortex-memory-instructions.md"
+        memory_file.write_text("old content")
+
+        briefing_file = rules_dir / "cortex-briefing.md"
+        briefing_file.write_text("old briefing")
+
+        result = setup_claude_rules(str(tmp_path), force=True)
+
+        # Files should be created (overwritten)
+        assert str(memory_file) in result["created"]
+        assert str(briefing_file) in result["created"]
+        assert len(result["skipped"]) == 0
+
+        # Content should be new
+        assert "[MEMORY:" in memory_file.read_text()
+        assert "auto-populated" in briefing_file.read_text()
+
+    def test_handles_existing_claude_directory(self, tmp_path):
+        """Test works when .claude/ already exists but not rules/."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{}")
+
+        result = setup_claude_rules(str(tmp_path))
+
+        assert len(result["errors"]) == 0
+        assert len(result["created"]) == 2
+        assert (tmp_path / ".claude" / "rules" / "cortex-memory-instructions.md").exists()


### PR DESCRIPTION
## Summary

- Add `--setup` flag to `cortex init` that creates `.claude/rules/` directory with Cortex template files
- New `setup_claude_rules()` function handles directory creation and template copying
- Templates included in package distribution via `pyproject.toml` package-data config
- `--force` flag allows overwriting existing files

## Files created by `--setup`

| File | Purpose |
|------|---------|
| `.claude/rules/cortex-memory-instructions.md` | Guide for using `[MEMORY:]` tags |
| `.claude/rules/cortex-briefing.md` | Placeholder for briefing content |

## Test plan

- [x] 6 new tests for `setup_claude_rules()` covering directory creation, file content, skip/force behavior
- [x] Tests for `cmd_init()` with `--setup` flag
- [x] All 721 tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, pytest, secrets detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --setup and --force flags to init to create or overwrite Claude integration files for memory instructions and briefing
  * Added --dry-run and --force flags to upgrade to preview or force upgrades
  * Templates for the memory instructions/briefing are now included in distributions

* **Tests**
  * Added tests covering init --setup behavior, file creation/overwrite, and reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->