### PR TITLE
chore: nest tools config under reviews in .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -76,22 +76,22 @@ reviews:
     unit_tests:
       enabled: true
 
-# Enable linters that match local tooling
-tools:
-  ruff:
-    enabled: true
-  eslint:
-    enabled: true
-  shellcheck:
-    enabled: true
-  markdownlint:
-    enabled: true
-  gitleaks:
-    enabled: true
-  yamllint:
-    enabled: true
-  actionlint:
-    enabled: true
+  # Enable linters that match local tooling
+  tools:
+    ruff:
+      enabled: true
+    eslint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## What

Moves the `tools:` block in `.coderabbit.yaml` from the top level to under `reviews:` (indented two more spaces). No values changed.

## Why

CodeRabbit's schema v2 has no top-level `tools` key — per-tool settings live under `reviews.tools`. The top-level block was being **silently ignored at runtime**. The only signal is a one-line `Unrecognized key: "tools"` note on the PR walkthrough, which is easy to read straight past.

## Behavior impact

None, as it happens — but not by design. All seven linters (ruff, eslint, shellcheck, markdownlint, gitleaks, yamllint, actionlint) default to `enabled: true` in the schema, so the ignored block coincidentally matched the fallback defaults. Nesting it correctly pins that intent against any future change to those upstream defaults.

## Verification

Two independent checks against the official schema (`coderabbit.ai/integrations/schema.v2.json`):

1. **CodeRabbit CLI** (`cr config validate`, v0.7.1). Before:
   ```
   Line 80  tools: Property should not be at root level.
            This property belongs under: reviews.tools
   ```
   After: `.coderabbit.yaml is valid against the current CodeRabbit schema.`

2. **Independent key walk** over the schema's properties tree — 0 errors, and it confirms `tools` was the *only* unrecognized key in the file. No other schema drift.

Both validators were sanity-checked against known-bad and known-good controls (the klockthingy config either side of its fix) so that a pass means "checked and clean" rather than "the check never ran".

## Related

Same defect and same fix as As-The-Geek-Learns/klockthingy#118 (commit 47788c4) — this patch is byte-identical to that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted configuration indentation without changing enabled tools or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->