### PR TITLE
chore(ci): pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # CI Workflow for cortex
 # =============================================================================
-# Runs on every push and pull request to main.
+# Runs on every push to main, on all pull requests, and weekly on main.
 #
 # Jobs:
 #   1. python-quality       - Lint and format check Python code
@@ -12,6 +12,24 @@
 #   6. security-scan        - Semgrep static analysis
 #   7. secrets-scan         - Gitleaks for accidentally committed secrets
 #   8. workflow-verify      - Ironclad workflow gate (verify + ship dry-run)
+#
+# WHY every `uses:` is pinned to a full-length commit SHA: a tag is a mutable
+# pointer, so `actions/checkout@v6` runs whatever code that tag resolves to on
+# the day the job starts. An org-level policy on As-The-Geek-Learns now
+# requires SHA pins and rejects tag refs at "Set up job", before any step of
+# any job runs. The trailing `# v6` comment keeps the pin human-readable and
+# is the half Dependabot rewrites alongside the SHA when it bumps an action —
+# do not drop it.
+#
+# WHY the weekly schedule: this workflow depends on things that change outside
+# the repo — org-level Actions policy, the Semgrep rulesets, and a Gitleaks
+# tarball fetched from a GitHub release URL. Event triggers alone only exercise
+# main when someone pushes, so drift stays invisible until an unrelated PR
+# trips over it. That already happened here: main's last CI run was 2026-02-24,
+# the SHA-pinning policy landed sometime between 2026-05-11 (the last PR run
+# that still passed) and 2026-08-02, and main kept showing a stale green the
+# whole time — the breakage only surfaced when PR #55 failed at "Set up job".
+# A weekly run on main bounds that blind spot to 7 days.
 # =============================================================================
 
 name: CI
@@ -21,9 +39,19 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Mondays 07:17 UTC. Off the hour on purpose — scheduled jobs queue behind
+    # the crowd that picks :00, and GitHub may drop runs under peak load.
+    - cron: '17 7 * * 1'
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # event_name is part of the key so the weekly run and a push to main — which
+  # share a ref — cannot cancel each other. Without it, cancel-in-progress lets
+  # a scheduled run kill an in-flight push run on main (and vice versa), leaving
+  # a "cancelled" result where a real pass/fail verdict should be. Runs of the
+  # same event still supersede each other as before.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -44,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -71,10 +99,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -95,10 +123,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -123,10 +151,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -152,10 +180,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -173,7 +201,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run Semgrep
         uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
@@ -197,7 +225,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -227,15 +255,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "20"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.7.0
+        uses: dependabot/fetch-metadata@8348ea7f5d949b08c7f125a44b569c9626b05db3 # v1.7.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Problem

Every CI job fails at **"Set up job"** — before a single check runs:

> The actions `actions/checkout@v6` and `actions/setup-python@v6` are not allowed in
> `As-The-Geek-Learns/cortex` because all actions must be pinned to a full-length commit SHA.

An org-level GitHub Actions policy now requires SHA-pinned actions. This blocks #55 and
every future PR.

`main` still shows green only because **its last CI run was 2026-02-24** — five months
stale. Verified against run history: PR runs still passed as recently as 2026-05-11, so the
policy landed between then and today, and #55 is the first PR to hit it.

## Change

Pins the 16 unpinned `uses:` references (17 total; `returntocorp/semgrep-action` was already
pinned) to the commit each tag currently resolves to, keeping the version in a trailing
comment:

| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | v6 | `d23441a48e516b6c34aea4fa41551a30e30af803` |
| `actions/setup-python` | v6 | `ece7cb06caefa5fff74198d8649806c4678c61a1` |
| `actions/setup-node` | v6 | `249970729cb0ef3589644e2896645e5dc5ba9c38` |
| `dependabot/fetch-metadata` | v1.7.0 | `8348ea7f5d949b08c7f125a44b569c9626b05db3` |
| `returntocorp/semgrep-action` | v1 | `713efdd345f3035192eaa63f56867b88e63e4e5d` (unchanged) |

Also adds a **weekly scheduled run** (Mondays 07:17 UTC) and `workflow_dispatch`, and adds
`github.event_name` to the concurrency key.

No job's steps change behavior. The trailing `# vX` comments are load-bearing — Dependabot
rewrites the SHA and the comment together.

## Why the weekly schedule

Event triggers alone only exercise `main` when someone pushes, so external drift stays
invisible until an unrelated PR trips over it — which is exactly what happened here. A
weekly run on `main` bounds that blind spot to 7 days.

`github.event_name` is in the concurrency key so the scheduled run and a push to `main` —
which share a ref — cannot cancel each other. Without it, `cancel-in-progress` lets one kill
the other, leaving a "cancelled" result where a real verdict should be.

## Verification

- All 17 `uses:` match `@<40-hex>`; zero tag refs remain.
- Both workflow files parse as YAML; `ci.yml` retains all 8 jobs and now carries
  `push`/`pull_request`/`schedule`/`workflow_dispatch`.
- **Each SHA round-trips**: re-resolved every pinned SHA from the file back through
  `gh api repos/OWNER/REPO/commits/TAG --jq .sha` and confirmed it matches the tag in its
  comment. (`/commits/TAG` is used deliberately over `/git/ref/tags/TAG` — the latter returns
  the *tag object* SHA for annotated tags, which Actions cannot resolve.)
- The real proof is this PR's own checks: if the pins are wrong, it fails at "Set up job"
  exactly as #55 does.

## Notes

- `dependabot/fetch-metadata` is pinned at the version currently in the file (v1.7.0), not
  bumped. #53 already proposes 1.7.0 → 3.1.0; keeping the bump separate leaves both changes
  independently revertible. **#53 will need a rebase after this merges.**
- Reference implementation: `As-The-Geek-Learns/resist-and-rise` b087ad7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
