### PR TITLE
fix(lint): exclude Markdown from Ruff formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ exclude = [
     "__pycache__",
     "venv",
     ".venv",
+    # Ruff 0.16 extended the formatter to Python code blocks inside Markdown,
+    # which silently widened `ruff format .` from 61 files to 110 and started
+    # rewriting illustrative snippets in prose docs (SECURITY-REVIEW.md, session
+    # notes, research phases). CI installs Ruff unpinned, so this landed with no
+    # code change on our side and only surfaced once CI could run again.
+    # The python-quality job exists to check Python source; docs are prose whose
+    # snippets are deliberately abbreviated and not always valid standalone.
+    "*.md",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
> **Ordering: merge #56 first.** This branch is cut from `chore/pin-actions-to-sha`, so against
> `main` it currently shows both commits. Once #56 merges, GitHub recomputes and this PR reduces
> to the single one-line `exclude` change. Base is `main` (not #56's branch) on purpose — with a
> non-`main` base, `ci.yml`'s `pull_request: branches: [main]` filter suppresses CI entirely and
> this PR gets no verification at all.

## Problem

With #56 letting CI actually execute again, two jobs fail — `Python Quality` and the `Lint`
stage of `Workflow Verify` — on four Markdown files nobody has edited since **2026-01-31**:

- `.github/SECURITY-REVIEW.md`
- `.workflow/checklists/security-review.md`
- `docs/research/phases/05-deep-research.md`
- `docs/sessions/SESSION-2026-01-31-tier0-phase3.md`

Nothing in the repo changed. **Ruff did.** Newer Ruff extends the formatter to Python code
blocks inside Markdown, silently widening `ruff format .` from 61 files to 110 and rewriting
illustrative snippets in prose docs — quote style and blank lines in, among others, our own
security review checklist.

## Evidence (by version, not inference)

Same tree, two Ruff versions:

| Ruff | Result |
|---|---|
| 0.9.10 — current when `main` last ran CI (2026-02-24) | `61 files already formatted` ✅ |
| 0.16.1 — what CI installs today | `4 files would be reformatted, 110 files already formatted` ❌ |

CI installs Ruff with a bare `pip install ruff`, so it always gets the newest release.
Combined with `main` not having run CI since February, the drift was invisible until #56
let jobs execute again. Same failure mode as the unpinned action tags, one layer down.

## Change

One `exclude` entry: `"*.md"`. The `python-quality` job then checks what its own description
says it checks — Python source. Docs are prose, and their snippets are deliberately
abbreviated and not always valid standalone.

## Verification

- `npm run lint` (the exact CI command, `ruff check . && ruff format --check .`) exits **0**
  — exit code captured directly, not through a pipe.
- **Both** Ruff 0.9.10 and 0.16.1 now report the identical `61 files already formatted` —
  the exact pre-drift state, so this restores prior behavior rather than papering over it.
- Python coverage is unchanged at 61 files: the exclusion hides no real Python. Verified
  `ruff format --check . --exclude "*.md"` reports zero would-be-reformatted files.
- This PR's own CI run is the end-to-end proof: pinned actions **and** the lint fix together.

## Deliberately not fixed here

The unpinned `pip install ruff` in `ci.yml`. Pinning the toolchain is a genuine follow-up
with its own maintenance cost (Dependabot won't track a bare `pip install` inside a `run:`
step), and it doesn't belong in a one-line exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality tooling to exclude Markdown documentation from automated formatting checks.
  * Added configuration comments explaining formatting behavior and documentation exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->