### PR TITLE
chore(ci): pin CI toolchain, gate Dependabot auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,11 @@ jobs:
           python-version: "3.11"
 
       - name: Install Ruff
-        run: pip install ruff
+        # -c pins to the version in requirements-dev.txt without installing the
+        # rest of it. A bare `pip install ruff` takes whatever is newest, which
+        # is how Ruff 0.16 silently replaced the pinned 0.15.1 and started
+        # reformatting Markdown code blocks (see #57).
+        run: pip install ruff -c requirements-dev.txt
 
       - name: Run Ruff Linter
         run: ruff check . --output-format=github
@@ -107,7 +111,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install mypy
-        run: pip install mypy
+        run: pip install mypy -c requirements-dev.txt
 
       - name: Run mypy
         run: mypy src/cortex --ignore-missing-imports
@@ -134,7 +138,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install pip-audit
-        run: pip install pip-audit
+        run: pip install pip-audit -c requirements-dev.txt
 
       - name: Run pip-audit
         run: pip-audit --strict --vulnerability-service pypi
@@ -159,7 +163,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt pytest
+        run: pip install -r requirements.txt pytest -c requirements-dev.txt
 
       - name: Run tests
         run: pytest tests/ -v
@@ -268,7 +272,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt pytest ruff pip-audit
+        run: pip install -r requirements.txt pytest ruff pip-audit -c requirements-dev.txt
 
       - name: Run workflow verify
         # Skip AI review in CI - it's non-deterministic and useful for local dev only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,15 @@ jobs:
           python-version: "3.11"
 
       - name: Install Ruff
-        # -c pins to the version in requirements-dev.txt without installing the
-        # rest of it. A bare `pip install ruff` takes whatever is newest, which
-        # is how Ruff 0.16 silently replaced the pinned 0.15.1 and started
-        # reformatting Markdown code blocks (see #57).
-        run: pip install ruff -c requirements-dev.txt
+        # -c pins to the version in requirements-tools.txt without installing
+        # the rest of it. A bare `pip install ruff` takes whatever is newest,
+        # which is how Ruff 0.16 silently replaced the pinned 0.15.1 and started
+        # reformatting Markdown code blocks (see #57). Constraining against
+        # requirements-tools.txt rather than requirements-dev.txt matters: the
+        # latter includes `-r requirements.txt`, and pip resolves a constraints
+        # file in full, so it dragged in sentence-transformers/torch metadata
+        # and took 62s instead of 2s.
+        run: pip install ruff -c requirements-tools.txt
 
       - name: Run Ruff Linter
         run: ruff check . --output-format=github
@@ -111,7 +115,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install mypy
-        run: pip install mypy -c requirements-dev.txt
+        run: pip install mypy -c requirements-tools.txt
 
       - name: Run mypy
         run: mypy src/cortex --ignore-missing-imports
@@ -138,7 +142,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install pip-audit
-        run: pip install pip-audit -c requirements-dev.txt
+        run: pip install pip-audit -c requirements-tools.txt
 
       - name: Run pip-audit
         run: pip-audit --strict --vulnerability-service pypi
@@ -163,7 +167,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt pytest -c requirements-dev.txt
+        run: pip install -r requirements.txt pytest -c requirements-tools.txt
 
       - name: Run tests
         run: pytest tests/ -v
@@ -272,7 +276,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt pytest ruff pip-audit -c requirements-dev.txt
+        run: pip install -r requirements.txt pytest ruff pip-audit -c requirements-tools.txt
 
       - name: Run workflow verify
         # Skip AI review in CI - it's non-deterministic and useful for local dev only

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,20 @@
+# =============================================================================
+# Dependabot Auto-Merge
+# =============================================================================
+# Approves and enables auto-merge for Dependabot PRs -- but only for patch and
+# minor bumps.
+#
+# WHY the gate: this workflow used to fetch update metadata and then never read
+# it, so every Dependabot PR was approved and squash-merged unconditionally,
+# major versions included. The `minor-and-patch` group in dependabot.yml is the
+# routine bucket; majors are a deliberate decision and now wait for a human.
+#
+# Note this bounds blast radius, it does not eliminate it: `gh pr merge --auto`
+# only waits on the repo's REQUIRED checks, currently just Semgrep and Gitleaks.
+# A patch bump that breaks lint, types, or tests can still auto-merge until
+# those jobs are made required in the branch ruleset.
+# =============================================================================
+
 name: Dependabot Auto-Merge
 
 on: pull_request
@@ -18,6 +35,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
           gh pr review --approve "$PR_URL"
         env:
@@ -25,8 +43,18 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Explain skipped major bump
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "Auto-merge skipped: this is a **major** version bump (\`$UPDATE_TYPE\`), which needs a human decision. Review the changelog, then merge manually if you want it."
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          UPDATE_TYPE: ${{steps.metadata.outputs.update-type}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,31 +2,14 @@
 # Cortex Development Dependencies
 # =============================================================================
 # Install: pip install -r requirements-dev.txt
+#
+# The tool versions themselves live in requirements-tools.txt so CI can use that
+# file as a pip constraints file cheaply -- see the header there for why. This
+# file stays the one command a developer needs.
 # =============================================================================
 
 # Include runtime dependencies
 -r requirements.txt
 
-# -----------------------------------------------------------------------------
-# Testing
-# -----------------------------------------------------------------------------
-pytest==9.0.2
-pytest-cov==7.0.0
-pytest-mock==3.15.1
-
-# -----------------------------------------------------------------------------
-# Code Quality
-# -----------------------------------------------------------------------------
-ruff==0.15.1
-mypy==1.19.1
-
-# -----------------------------------------------------------------------------
-# Security Scanning
-# -----------------------------------------------------------------------------
-pip-audit==2.10.0
-semgrep==1.151.0
-
-# -----------------------------------------------------------------------------
-# Git Hooks
-# -----------------------------------------------------------------------------
-pre-commit==4.5.1
+# Pinned developer tooling (also used by CI via `-c requirements-tools.txt`)
+-r requirements-tools.txt

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,0 +1,43 @@
+# =============================================================================
+# Cortex Developer Tool Pins
+# =============================================================================
+# The exact versions of the tools that run in CI. Pulled out of
+# requirements-dev.txt so CI can use it as a pip CONSTRAINTS file:
+#
+#   pip install ruff -c requirements-tools.txt
+#
+# WHY it is a separate file: a constraints file is fully resolved even when
+# nothing in it is being installed. requirements-dev.txt starts with
+# `-r requirements.txt`, so using it as constraints made pip resolve
+# sentence-transformers (and therefore torch) metadata just to install Ruff --
+# measured at 62s versus 2s. This file has no includes, so constraining against
+# it costs nothing.
+#
+# Humans still install requirements-dev.txt; it pulls this in via `-r`, so these
+# versions remain the single source of truth. Dependabot tracks the file because
+# the name matches its requirements*.txt discovery pattern.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Testing
+# -----------------------------------------------------------------------------
+pytest==9.0.2
+pytest-cov==7.0.0
+pytest-mock==3.15.1
+
+# -----------------------------------------------------------------------------
+# Code Quality
+# -----------------------------------------------------------------------------
+ruff==0.15.1
+mypy==1.19.1
+
+# -----------------------------------------------------------------------------
+# Security Scanning
+# -----------------------------------------------------------------------------
+pip-audit==2.10.0
+semgrep==1.151.0
+
+# -----------------------------------------------------------------------------
+# Git Hooks
+# -----------------------------------------------------------------------------
+pre-commit==4.5.1


### PR DESCRIPTION
Follow-ups to #56 and #57. Three commits, each independently revertible.

## 1. Pin the CI toolchain (`658b648`)

`requirements-dev.txt` **already pinned every dev tool** — and `ci.yml` referenced it
**zero times**:

```
pytest==9.0.2   ruff==0.15.1   mypy==1.19.1   pip-audit==2.10.0
```

Jobs ran `pip install ruff`, `pip install mypy`, `pip install pip-audit` bare, so CI
always installed whatever was newest on PyPI instead of the version this repo declares.

**That gap is what broke CI today.** Verified: Ruff **0.15.1 — the version already pinned
here** — reports `61 files already formatted` on the tree as of the #56 merge. The #57
failure could not have happened if CI had installed the pin it already had. This was never
a missing pin; it was CI ignoring one.

## 2. Gate Dependabot auto-merge (`1115cf4`)

The workflow fetched update metadata into `id: metadata` and **never read it**. Nothing
referenced the outputs, so every Dependabot PR was approved and squash-merged
unconditionally — **major bumps included**.

Now gates on the metadata already being fetched: patch and minor merge as before, majors
stop and get a comment explaining why. Matches `dependabot.yml`, which already treats
`minor-and-patch` as the routine group.

## 3. Make the constraints cheap (`47f9f92`)

Commit 1 worked but cost real time — `python-quality` went **11s → 1m31s**. pip resolves a
constraints file in full even when installing nothing from it, and `requirements-dev.txt`
opens with `-r requirements.txt`, so every tool install pulled `sentence-transformers`
(hence torch) metadata just to learn which Ruff to fetch.

Measured in a clean venv, no cache:

| Command | Time | Result |
|---|---|---|
| `pip install ruff` | 2s | ruff 0.16.1 — **unpinned** |
| `pip install ruff -c requirements-dev.txt` | 62s | ruff 0.15.1 |
| `pip install ruff -c requirements-tools.txt` | **3s** | **ruff 0.15.1** |

Moves the pins into `requirements-tools.txt` (no includes) and has `requirements-dev.txt`
pull it in via `-r`. Developers still run one command; CI constrains against the lean file.

**Equivalence proved:** expanding both files transitively resolves `requirements-dev.txt`
to a byte-identical dependency set before and after. The filename matches Dependabot's
`requirements*.txt` discovery pattern, so bumps keep arriving as PRs — already demonstrated
by #50 bumping `pytest 9.0.2 → 9.0.3`, a pin that lives only in these dev files.

## Known remaining gap (not fixed here)

`gh pr merge --auto` waits only on **required** checks — currently just `Security Scan
(Semgrep)` and `Secrets Scan`. A patch bump that breaks lint, types, or tests can still
auto-merge. Closing that means making those jobs required in the branch ruleset — a repo
settings change and your call, so it's documented in the workflow header rather than
changed silently.

## Verification

- Both workflows parse; `ci.yml` keeps all 8 jobs; the three `if:` gates are present.
- Every **tool** install carries `-c requirements-tools.txt`. `pip install -r
  requirements.txt` in `python-security` is left unconstrained on purpose — that job audits
  runtime deps and should resolve the ranges a real user gets.
- Version resolution confirmed by `pip install --dry-run`: ruff 0.15.1, mypy 1.19.1,
  pip_audit 2.10.0, pytest 9.0.2.
- Watch `Python Quality` on this run: it should be back to ~10s, not 1m31s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
