### PR TITLE
fix(testing): stop the Phase 2 sandbox writing to the surrounding repository

### DIFF
--- a/scripts/testing/test_environment.py
+++ b/scripts/testing/test_environment.py
@@ -6,6 +6,7 @@
 #       config monkeypatching so hooks run against temp storage.
 """
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -13,6 +14,36 @@ from pathlib import Path
 
 from cortex.config import CortexConfig
 from cortex.project import get_project_hash
+
+# WHAT: git environment variables that must never reach the sandbox.
+# WHY: git honours GIT_DIR from the environment even when cwd= (or -C) points
+#      somewhere else, and git exports GIT_DIR to every hook it runs. Under a
+#      hook, `git init` below would not create a repo here -- it would
+#      re-initialise the CALLING repository, and every command after it would
+#      write to that repo instead: `git config` overwrites its identity,
+#      `git add .` stages sandbox files into its index, `git commit` creates a
+#      real commit, and `git branch -M main` renames its current branch.
+#      Verified 2026-08-08: all of them return 0, so capture_output=True hides
+#      the whole thing. A sibling repo lost its shared config to this exact
+#      mechanism before it was understood.
+_AMBIENT_GIT_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+    "GIT_NAMESPACE",
+)
+
+
+def _hermetic_git_env() -> dict[str, str]:
+    """Return a copy of os.environ with every ambient git pointer removed."""
+    env = os.environ.copy()
+    for var in _AMBIENT_GIT_VARS:
+        env.pop(var, None)
+    return env
 
 
 class TestEnvironment:
@@ -39,29 +70,76 @@ class TestEnvironment:
 
         # WHAT: Initialize a git repo with an initial commit.
         # WHY: identify_project() calls git rev-parse, which needs a repo.
-        subprocess.run(["git", "init"], cwd=self.project_dir, capture_output=True)
+        #
+        # Every call passes env=git_env so no ambient GIT_DIR can redirect it at
+        # the calling repository -- see _AMBIENT_GIT_VARS above.
+        git_env = _hermetic_git_env()
+        subprocess.run(
+            ["git", "init"],
+            cwd=self.project_dir,
+            capture_output=True,
+            env=git_env,
+        )
+
+        # WHAT: Confirm the repo we just made is actually HERE before writing to it.
+        # WHY: the scrub above is the fix; this is what makes a regression loud.
+        #      Every git call in this method returns 0 while silently operating on
+        #      another repository, so without this check the damage is invisible --
+        #      and the commands below commit and rename branches.
+        #
+        # Ask for --absolute-git-dir, NOT --show-toplevel. With an ambient GIT_DIR
+        # and no GIT_WORK_TREE, git treats the cwd as the work tree, so
+        # --show-toplevel cheerfully reports this sandbox while the object store,
+        # index and refs all belong to the other repo. Checked 2026-08-08: a guard
+        # written against --show-toplevel passes while a commit lands elsewhere.
+        # The git dir is the thing that cannot lie about which repo is being written.
+        probe = subprocess.run(
+            ["git", "rev-parse", "--absolute-git-dir"],
+            cwd=self.project_dir,
+            capture_output=True,
+            text=True,
+            env=git_env,
+        )
+        actual = Path(probe.stdout.strip()).resolve() if probe.stdout.strip() else None
+        expected = (self.project_dir / ".git").resolve()
+        if actual != expected:
+            raise RuntimeError(
+                f"Sandbox git dir is {actual or '<none>'}, expected {expected}. "
+                "An ambient GIT_DIR is leaking in; refusing to run git commands "
+                "against another repository."
+            )
+
         subprocess.run(
             ["git", "config", "user.email", "test@cortex.dev"],
             cwd=self.project_dir,
             capture_output=True,
+            env=git_env,
         )
         subprocess.run(
             ["git", "config", "user.name", "Cortex Test"],
             cwd=self.project_dir,
             capture_output=True,
+            env=git_env,
         )
         readme = self.project_dir / "README.md"
         readme.write_text("# Cortex Test Project\n")
-        subprocess.run(["git", "add", "."], cwd=self.project_dir, capture_output=True)
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=self.project_dir,
+            capture_output=True,
+            env=git_env,
+        )
         subprocess.run(
             ["git", "commit", "-m", "Initial commit"],
             cwd=self.project_dir,
             capture_output=True,
+            env=git_env,
         )
         subprocess.run(
             ["git", "branch", "-M", "main"],
             cwd=self.project_dir,
             capture_output=True,
+            env=git_env,
         )
 
         # WHAT: Create the .claude/rules/ directory for briefing output.

--- a/tests/test_sandbox_hermeticity.py
+++ b/tests/test_sandbox_hermeticity.py
@@ -1,7 +1,7 @@
 """Tests that the Phase 2 test sandbox cannot touch the surrounding repository.
 
 Tests cover:
-- TestEnvironment.setup() stays hermetic when an ambient GIT_DIR is present
+- TestEnvironment.setup() stays hermetic under each ambient git variable
 - the guard in setup() raises, rather than proceeding, if the scrub regresses
 
 WHY these exist: git honours GIT_DIR from the environment even when cwd= points
@@ -12,6 +12,7 @@ files into its index, creating a commit, and renaming its branch to main. Every 
 those git calls returns 0 and is run with capture_output=True, so nothing surfaced.
 """
 
+import hashlib
 import os
 import subprocess
 from pathlib import Path
@@ -56,14 +57,34 @@ def victim_repo(tmp_path: Path) -> Path:
 
 
 def _snapshot(repo: Path) -> dict:
-    """Capture every property the unscrubbed git calls would have damaged."""
+    """Capture every property the unscrubbed git calls would have damaged.
+
+    Includes the object store and the raw index, not just the porcelain output:
+    GIT_OBJECT_DIRECTORY and GIT_INDEX_FILE redirect writes at those two files
+    specifically, and they do it while `git rev-parse --absolute-git-dir` still
+    reports the sandbox. A snapshot built only from config and rev-list would
+    show no difference.
+    """
+    objects_dir = repo / ".git" / "objects"
+    index = repo / ".git" / "index"
     return {
         "email": _git(["git", "config", "--get", "user.email"], repo),
         "branch": _git(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo),
         "commits": _git(["git", "rev-list", "--count", "HEAD"], repo),
         "staged": _git(["git", "diff", "--cached", "--name-only"], repo),
         "bare": _git(["git", "config", "--get", "core.bare"], repo),
+        "objects": sorted(str(p.relative_to(objects_dir)) for p in objects_dir.rglob("*") if p.is_file()),
+        "index": hashlib.sha256(index.read_bytes()).hexdigest() if index.exists() else None,
     }
+
+
+def _hostile_value(var: str, repo: Path) -> str:
+    """The value of `var` that would point git at `repo` instead of the sandbox."""
+    return {
+        "GIT_DIR": str(repo / ".git"),
+        "GIT_INDEX_FILE": str(repo / ".git" / "index"),
+        "GIT_OBJECT_DIRECTORY": str(repo / ".git" / "objects"),
+    }[var]
 
 
 # =============================================================================
@@ -71,10 +92,22 @@ def _snapshot(repo: Path) -> dict:
 # =============================================================================
 
 
-def test_sandbox_is_hermetic_under_ambient_git_dir(victim_repo, monkeypatch):
-    """An inherited GIT_DIR must not redirect the sandbox at another repo."""
+@pytest.mark.parametrize(
+    "var",
+    ["GIT_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY"],
+)
+def test_sandbox_is_hermetic_under_ambient_git_var(victim_repo, monkeypatch, var):
+    """No inherited git variable may redirect the sandbox at another repo.
+
+    Parametrised because the git-dir guard in setup() only catches the GIT_DIR case.
+    GIT_INDEX_FILE and GIT_OBJECT_DIRECTORY leave --absolute-git-dir pointing at the
+    sandbox, so the guard passes while writes land in the victim -- measured
+    2026-08-08: with GIT_OBJECT_DIRECTORY set, three sandbox objects (including the
+    file's blob) were written into the victim's object store. For those two the env
+    scrub is the ONLY protection, so it needs its own regression coverage.
+    """
     before = _snapshot(victim_repo)
-    monkeypatch.setenv("GIT_DIR", str(victim_repo / ".git"))
+    monkeypatch.setenv(var, _hostile_value(var, victim_repo))
 
     env = SandboxEnvironment()
     env.setup()

--- a/tests/test_sandbox_hermeticity.py
+++ b/tests/test_sandbox_hermeticity.py
@@ -1,0 +1,108 @@
+"""Tests that the Phase 2 test sandbox cannot touch the surrounding repository.
+
+Tests cover:
+- TestEnvironment.setup() stays hermetic when an ambient GIT_DIR is present
+- the guard in setup() raises, rather than proceeding, if the scrub regresses
+
+WHY these exist: git honours GIT_DIR from the environment even when cwd= points
+somewhere else, and git exports GIT_DIR to every hook it runs. Before the scrub in
+test_environment.py, running this sandbox from inside a hook would have re-initialised
+the CALLING repository and then written to it -- overwriting its identity, staging
+files into its index, creating a commit, and renaming its branch to main. Every one of
+those git calls returns 0 and is run with capture_output=True, so nothing surfaced.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.testing import test_environment as te
+
+# Aliased: pytest tries to collect any class named Test* and warns that it cannot,
+# because this one takes constructor arguments. It is the subject, not a test case.
+from scripts.testing.test_environment import TestEnvironment as SandboxEnvironment
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _git(args, cwd):
+    """Run a git command against `cwd` and return stripped stdout.
+
+    Scrubs the ambient git variables. These tests deliberately set a hostile GIT_DIR,
+    and without scrubbing here the probe answers about THAT repo instead of the one
+    being asked about -- which reads as a failure of the code under test rather than
+    of the question. (It did, once.)
+    """
+    env = {k: v for k, v in os.environ.items() if k not in te._AMBIENT_GIT_VARS}
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, env=env).stdout.strip()
+
+
+@pytest.fixture
+def victim_repo(tmp_path: Path) -> Path:
+    """A real git repo that no test is allowed to modify."""
+    repo = tmp_path / "victim"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "real@real.com"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "real"], cwd=repo, capture_output=True)
+    (repo / "original.txt").write_text("original\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "victim initial"], cwd=repo, capture_output=True)
+    return repo
+
+
+def _snapshot(repo: Path) -> dict:
+    """Capture every property the unscrubbed git calls would have damaged."""
+    return {
+        "email": _git(["git", "config", "--get", "user.email"], repo),
+        "branch": _git(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo),
+        "commits": _git(["git", "rev-list", "--count", "HEAD"], repo),
+        "staged": _git(["git", "diff", "--cached", "--name-only"], repo),
+        "bare": _git(["git", "config", "--get", "core.bare"], repo),
+    }
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+def test_sandbox_is_hermetic_under_ambient_git_dir(victim_repo, monkeypatch):
+    """An inherited GIT_DIR must not redirect the sandbox at another repo."""
+    before = _snapshot(victim_repo)
+    monkeypatch.setenv("GIT_DIR", str(victim_repo / ".git"))
+
+    env = SandboxEnvironment()
+    env.setup()
+
+    # The sandbox owns its own git dir.
+    #
+    # Asserting on --absolute-git-dir, not --show-toplevel: with an ambient GIT_DIR
+    # and no GIT_WORK_TREE, git treats the cwd as the work tree, so --show-toplevel
+    # reports the sandbox even when the object store belongs to another repo. The
+    # git dir is the part that cannot lie.
+    git_dir = _git(["git", "rev-parse", "--absolute-git-dir"], env.project_dir)
+    assert Path(git_dir).resolve() == (env.project_dir / ".git").resolve()
+    assert _git(["git", "rev-list", "--count", "HEAD"], env.project_dir) == "1"
+
+    assert _snapshot(victim_repo) == before, "the sandbox modified the surrounding repo"
+
+
+def test_guard_raises_if_the_scrub_regresses(victim_repo, monkeypatch):
+    """If the env scrub is removed, setup() must abort instead of writing elsewhere.
+
+    The scrub is the fix; this guard is what keeps a regression loud. Without it the
+    damage is silent, and the calls after the guard commit and rename branches.
+    """
+    before = _snapshot(victim_repo)
+    monkeypatch.setenv("GIT_DIR", str(victim_repo / ".git"))
+    monkeypatch.setattr(te, "_hermetic_git_env", lambda: os.environ.copy())
+
+    with pytest.raises(RuntimeError, match="ambient GIT_DIR"):
+        SandboxEnvironment().setup()
+
+    assert _snapshot(victim_repo) == before, "aborted too late — the repo was already modified"


### PR DESCRIPTION
`TestEnvironment.setup()` built its sandbox with `subprocess.run(["git", ...], cwd=self.project_dir)`. **`cwd=` does not isolate git** — git honours `GIT_DIR` from the environment regardless, and git exports `GIT_DIR` to every hook it runs.

Under a hook, `git init` therefore did not create a repo in the sandbox. It re-initialised the **calling** repository, and every call after it wrote to that repo:

| call | effect on the caller |
|---|---|
| `git config user.email` | overwrote its identity |
| `git add .` | staged sandbox files into its index |
| `git commit` | created a real commit |
| `git branch -M main` | renamed its current branch |

Verified against a throwaway repo: **all four return 0**, and every call uses `capture_output=True`, so the damage was completely silent. A sibling repo (`astgl-animated-channel`) lost its shared config to this same mechanism before it was understood — `core.bare = true` plus a test identity written into `.git/config` mid-push, leaving it and both its worktrees unusable.

## Scope: latent, not live

`TestEnvironment` is used only by `scripts/testing/run_phase2.py`, which the pytest suite does not import, so the pre-push `pytest` step never reached it. Fixed rather than left, because `run_phase2.py` is one hook invocation away from the same outcome.

## The fix

1. `_hermetic_git_env()` strips `GIT_DIR` and the seven related `GIT_*` variables; every git call in `setup()` runs with it.
2. `setup()` asserts the sandbox owns its git dir before writing, and raises otherwise. The scrub is the fix; the guard is what keeps a regression **loud**, since the calls after it commit and rename branches.

The guard asks for `--absolute-git-dir`, **not** `--show-toplevel`. With an ambient `GIT_DIR` and no `GIT_WORK_TREE`, git treats the cwd as the work tree, so `--show-toplevel` reports the sandbox while the object store, index and refs belong to the other repo:

```
GIT_DIR=<victim>/.git, cwd=<sandbox>
  --show-toplevel      <sandbox>        ← lies
  --absolute-git-dir   <victim>/.git    ← the truth
```

A first version of this guard used `--show-toplevel`. The regression test caught it passing while a commit landed in the victim repo.

## Tests

`tests/test_sandbox_hermeticity.py` covers both directions:

- **hermetic under a hostile `GIT_DIR`** — victim's identity, branch, commit count, index and `core.bare` all unchanged
- **raises instead of proceeding** when the scrub is monkeypatched away, and aborts *before* the commit and branch rename

## Verification

```
2/2 new tests pass
ruff check + ruff format --check  clean
```

**The full suite was not run locally** — it needs `sentence-transformers`/torch. No other test imports this module (`test_phase4_scripts.py` imports different `scripts.testing` modules, which I checked), and CI runs `pytest tests/ -v` with the real dependency set, so this PR exercises it.

Branched from `origin/main` in a separate worktree, deliberately not from `fix/pytest-cve-2025-71176` — that checkout is mid-work with a dirty tree and is untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox isolation by preventing ambient Git settings from affecting repository operations.
  * Added validation to ensure Git commands target the sandbox repository.
  * Setup now reports an error instead of proceeding when repository isolation cannot be verified.

* **Tests**
  * Added coverage for sandbox behavior when external Git settings are present.
  * Verified that failures do not modify unrelated repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->