### PR TITLE
chore(docs): point stale As-The-Geek-Learns URLs at Jmeg8r

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ cortex init              # Print updated hooks with MCP config
 - Full MCP protocol compliance for mid-session queries
 - Sub-second projection generation
 
-All tiers implemented. See [releases](https://github.com/As-The-Geek-Learns/cortex/releases) for version history.
+All tiers implemented. See [releases](https://github.com/Jmeg8r/cortex/releases) for version history.
 
 ## Development Setup
 
@@ -275,7 +275,7 @@ pre-commit run --all-files  # All hooks
 
 ## Development Workflow (Ironclad)
 
-This project uses a 4-phase workflow: **PLAN → EXECUTE → VERIFY → SHIP** with human checkpoints. Workflow adapted from [Ironclad Development Workflow](https://github.com/As-The-Geek-Learns/WorkflowExperiment).
+This project uses a 4-phase workflow: **PLAN → EXECUTE → VERIFY → SHIP** with human checkpoints. Workflow adapted from [Ironclad Development Workflow](https://github.com/Jmeg8r/ironclad-workflow).
 
 - **PLAN:** Create `.workflow/sessions/SESSION-YYYY-MM-DD-[slug]/plan.md` from `.workflow/templates/plan-template.md`; get approval before coding.
 - **EXECUTE:** Implement tasks; update session docs; run `npm run lint` / `ruff check .` as you go.

--- a/docs/articles/ASTGL-cortex-event-sourced-memory.md
+++ b/docs/articles/ASTGL-cortex-event-sourced-memory.md
@@ -307,7 +307,7 @@ The AI assistant finally remembers.
 
 ## References
 
-- [Cortex GitHub Repository](https://github.com/As-The-Geek-Learns/cortex)
+- [Cortex GitHub Repository](https://github.com/Jmeg8r/cortex)
 - [Full Research Paper](docs/research/paper/cortex-research-paper.md)
 - [A/B Comparison Results](docs/testing/AB-COMPARISON-RESULTS.md)
-- [v0.3.0 Release Notes](https://github.com/As-The-Geek-Learns/cortex/releases/tag/v0.3.0)
+- [v0.3.0 Release Notes](https://github.com/Jmeg8r/cortex/releases/tag/v0.3.0)

--- a/docs/testing/CORTEX-PROJECT-NOTION-IMPORT.md
+++ b/docs/testing/CORTEX-PROJECT-NOTION-IMPORT.md
@@ -10,7 +10,7 @@
 
 > An event-sourced memory architecture for AI coding assistants. Solving the context window boundary problem through automatic session continuity.
 
-**Repository:** [cortex](https://github.com/As-The-Geek-Learns/cortex)
+**Repository:** [cortex](https://github.com/Jmeg8r/cortex)
 
 **Status:** Tier 0 Implementation COMPLETE | Real-World Testing IN PROGRESS
 


### PR DESCRIPTION
## What

Rewrites stale `As-The-Geek-Learns/<repo>` GitHub URLs to `Jmeg8r/` — **5 line(s)** across: `README.md`, `docs/articles/ASTGL-cortex-event-sourced-memory.md`, `docs/testing/CORTEX-PROJECT-NOTION-IMPORT.md`

The old URLs still redirect, which is why they survive: nothing breaks, so nothing reports them.

## Why this is not a blanket find-and-replace

A plain `s/As-The-Geek-Learns/Jmeg8r/` is wrong across this fleet in four ways, all found while
building this sweep:

1. **`POST /orgs/As-The-Geek-Learns/rulesets`** — an *organization* API path. `Jmeg8r` is a user,
   so `/orgs/Jmeg8r/...` does not exist.
2. **Prose about the organization** — `gh repo list As-The-Geek-Learns`,
   `repository(owner:"As-The-Geek-Learns")`, "transferred to the As-The-Geek-Learns org".
   Rewriting these turns true statements false.
3. **Four targets have no repo under `Jmeg8r`** — `klokkthingy` (a typo; 404 even on the old org),
   `WorkflowExperiment` and `memory-context-claude-ai` (old *names*, since renamed to
   `ironclad-workflow` and `cortex`, whose old URLs still 200 via GitHub's rename redirect), and
   `rulesets`. Rewriting the owner alone converts a working redirect into a 404.
4. **Binary files match the string too** (`astgl-store/data/knowledge.db`); `sed` would corrupt them.

So only `As-The-Geek-Learns/<target>` for targets on a **verified allowlist** is rewritten —
checked against `gh repo list Jmeg8r --limit 300` — and only in explicitly named files.

## Scope

Dated session records and status reports keep their original URLs. They record what happened;
rewriting a record to match present-day naming is a different act from fixing a live link.

## Verification

- **5 removed / 5 added**, and every changed line is byte-identical once the owner segment is
  normalised — proving nothing but the owner changed
- The sweep refuses to run if it finds **0** rewritable refs (a silent no-op reads exactly like a
  clean sweep) and refuses any file that is not text
- JSON / JS / TOML files re-parsed after the change
- **One of the five was NOT an owner-only change.** `README.md` linked to `As-The-Geek-Learns/WorkflowExperiment` — the **old name** of what is now `Jmeg8r/ironclad-workflow`. An owner-only rewrite would have produced `Jmeg8r/WorkflowExperiment`, which **404s**, converting a link that currently works via GitHub's rename redirect into one that does not. Corrected to the canonical URL and confirmed **HTTP 200**.
- Deliberately left: `ci.yml:18` ("an org-level policy on As-The-Geek-Learns") is a statement about an organization that still exists, not a link; and `docs/sessions/SESSION-2026-02-05-rename-to-cortex.md` records the rename from `memory-context-claude-ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository and release links in the README.
  * Refreshed reference links in the event-sourced memory article.
  * Updated the Cortex repository link in the Notion import testing guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->